### PR TITLE
fix: use suffix

### DIFF
--- a/craft-functions/simple-deduplicate/index.js
+++ b/craft-functions/simple-deduplicate/index.js
@@ -1,15 +1,15 @@
-// KVSの重複排除用プレフィクス。任意のプレフィクスを指定する。
-const DUP_PREFIX = 'functionName';
+// KVSの重複排除用サフィックス。任意のサフィックスを指定する
+const DUP_SUFFIX = 'functionName';
 
 /**
  * ファンクションの重複実行を検知します。
- * @param {string} id - Craft Functionsの実行を一意に識別するID. (data.id)
+ * @param {Object} id - Craft Functionsの実行を一意に識別するID. (data.id)
  * @param {Object} kvs - MODULES.kvs
- * @param {*} prefix - Function識別用のプレフィクス
+ * @param {*} suffix - Function識別用のサフィックス
  * @returns {Promise<boolean>} - すでに実行中であれば true を返却する。未実行であればKVSにレコードを書き込んでfalseを返却する。
  */
-async function isDuplicatedExec(id, kvs, prefix) {
-    const key = `${prefix}_${id}`;
+async function isDuplicatedExec(id, kvs, suffix) {
+    const key = `${id}_${suffix}`;
     const v = await kvs.get({key});
 
     if (v[key] != null) {
@@ -20,7 +20,7 @@ async function isDuplicatedExec(id, kvs, prefix) {
         const unixtimeMs = new Date().getTime();
         await kvs.checkAndWrite({
             key,
-            value: { id, prefix },
+            value: { id, suffix },
             operator: '<',
             unixtimeMs,
         });
@@ -37,8 +37,8 @@ async function isDuplicatedExec(id, kvs, prefix) {
 export default async function(data, {MODULES}) {
     const { logger, kvs } = MODULES;
 
-    if (await isDuplicatedExec(data.id, kvs, DUP_PREFIX)) {
-        logger.warn('duplicated execution.', data);
+    if (await isDuplicatedExec(data.id, kvs, DUP_SUFFIX)) {
+        logger.warn('duplicated execution.', data.id);
         return;
     }
 


### PR DESCRIPTION
[KARTE Craftでファンクションの重複実行を防ぐ](https://solution.plaid.co.jp/implementing-exactly-once-semantics-in-karte-craft) のコードを修正する

* Craft KVSではprefixを使うとhotspotになりやすいのでsuffixに変更する
* logger.warn で data を全て表示しているが、必要なのはIDだけなので data.id のみを渡す